### PR TITLE
Implement dynamic rate limiter

### DIFF
--- a/apis/caller.go
+++ b/apis/caller.go
@@ -2,16 +2,17 @@ package apis
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
+	"strconv"
+	"time"
 
 	"github.com/fond-of-vertigo/amazon-sp-api/constants"
 	"github.com/fond-of-vertigo/amazon-sp-api/httpx"
-	"golang.org/x/time/rate"
 )
 
 type CallResponse[responseBodyType any] struct {
@@ -25,7 +26,6 @@ type Call[responseType any] interface {
 	// WithRestrictedDataToken is optional and can be passed to replace the existing accessToken
 	WithRestrictedDataToken(*string) Call[responseType]
 	WithParseErrorListOnError(bool) Call[responseType]
-	WithRateLimiter(rateLimiter *rate.Limiter) Call[responseType]
 	// Execute will return response object on success
 	Execute(httpClient httpx.Client) (*CallResponse[responseType], error)
 }
@@ -44,7 +44,6 @@ type call[responseType any] struct {
 	Body                  []byte
 	RestrictedDataToken   *string
 	ParseErrorListOnError bool
-	RateLimiter           *rate.Limiter
 }
 
 func (a *call[responseType]) WithQueryParams(queryParams url.Values) Call[responseType] {
@@ -65,13 +64,9 @@ func (a *call[responseType]) WithParseErrorListOnError(parseErrList bool) Call[r
 	a.ParseErrorListOnError = parseErrList
 	return a
 }
-func (a *call[responseType]) WithRateLimiter(rateLimiter *rate.Limiter) Call[responseType] {
-	a.RateLimiter = rateLimiter
-	return a
-}
+
 func (a *call[responseType]) Execute(httpClient httpx.Client) (*CallResponse[responseType], error) {
 	resp, err := a.execute(httpClient)
-
 	if err != nil {
 		return nil, err
 	}
@@ -96,23 +91,56 @@ func (a *call[responseType]) Execute(httpClient httpx.Client) (*CallResponse[res
 }
 
 func (a *call[responseType]) execute(httpClient httpx.Client) (*http.Response, error) {
+	attempts := 1
+	for {
+		if attempts >= constants.MaxRetryCount {
+			return nil, fmt.Errorf("max retry count of %d reached", constants.MaxRetryCount)
+		}
 
-	req, err := a.createNewRequest(httpClient.GetEndpoint())
-	if err != nil {
-		return nil, err
-	}
-	if a.RateLimiter != nil {
-		err = a.RateLimiter.Wait(context.Background())
+		req, err := a.createNewRequest(httpClient.GetEndpoint())
 		if err != nil {
 			return nil, err
 		}
+
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+
+		if resp.StatusCode == http.StatusTooManyRequests {
+			if err := waitForRetry(resp); err != nil {
+				return resp, err
+			}
+			attempts++
+			continue
+		}
+		return resp, err
 	}
-	resp, err := httpClient.Do(req)
+}
+
+func waitForRetry(resp *http.Response) error {
+	backOffTime, err := getBackoffDelay(resp)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	return resp, err
+	time.Sleep(backOffTime)
+	return nil
+}
+
+func getBackoffDelay(resp *http.Response) (time.Duration, error) {
+	backOffTimeHeader := resp.Header.Get(constants.RateLimitHeader)
+	if backOffTimeHeader == "" {
+		return constants.RetryDelay, nil
+	}
+
+	reqPerSecond, err := strconv.ParseFloat(backOffTimeHeader, 64)
+	if err != nil {
+		return constants.RetryDelay, fmt.Errorf("error parsing backoff delay: %w", err)
+	}
+
+	backOffTime := time.Duration(math.Abs(1/reqPerSecond)) * time.Second
+	return backOffTime, nil
 }
 
 func (a *call[responseType]) createNewRequest(endpoint constants.Endpoint) (*http.Request, error) {

--- a/apis/caller_test.go
+++ b/apis/caller_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+	"time"
 )
 
 type dummyHttpClient struct {
@@ -264,4 +265,65 @@ func getJSONBytes(obj any) ([]byte, error) {
 		return []byte{}, nil
 	}
 	return json.Marshal(obj)
+}
+
+func Test_getBackoffDelay(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     *http.Response
+		want    time.Duration
+		wantErr bool
+	}{
+		{
+			name:    "Simple",
+			arg:     newMockResponseWithHeader(map[string]string{constants.RateLimitHeader: "0.5"}),
+			want:    2 * time.Second,
+			wantErr: false,
+		},
+		{
+			name:    "No Header set",
+			arg:     &http.Response{},
+			want:    constants.RetryDelay,
+			wantErr: false,
+		},
+		{
+			name:    "Header set but empty",
+			arg:     newMockResponseWithHeader(map[string]string{constants.RateLimitHeader: ""}),
+			want:    constants.RetryDelay,
+			wantErr: false,
+		},
+		{
+			name:    "Header set but invalid",
+			arg:     newMockResponseWithHeader(map[string]string{constants.RateLimitHeader: "invalid"}),
+			want:    constants.RetryDelay,
+			wantErr: true,
+		},
+		{
+			name:    "Header set to negative",
+			arg:     newMockResponseWithHeader(map[string]string{constants.RateLimitHeader: "-2"}),
+			want:    time.Duration(1/2) * time.Second,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getBackoffDelay(tt.arg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getBackoffDelay() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("getBackoffDelay() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func newMockResponseWithHeader(headerMap map[string]string) *http.Response {
+	r := http.Response{}
+	r.Header = http.Header{}
+	for k, v := range headerMap {
+		r.Header.Set(k, v)
+	}
+	return &r
 }

--- a/apis/finances/finances.go
+++ b/apis/finances/finances.go
@@ -2,12 +2,9 @@ package finances
 
 import (
 	"errors"
-	"net/http"
-	"time"
-
 	"github.com/fond-of-vertigo/amazon-sp-api/apis"
 	"github.com/fond-of-vertigo/amazon-sp-api/httpx"
-	"golang.org/x/time/rate"
+	"net/http"
 )
 
 const pathPrefix = "/finances/v0"
@@ -24,20 +21,12 @@ type API interface {
 }
 
 type api struct {
-	HttpClient                            httpx.Client
-	RateLimitListFinancialEventGroups     *rate.Limiter
-	RateLimitListFinancialEventsByGroupID *rate.Limiter
-	RateLimitListFinancialEventsByOrderID *rate.Limiter
-	RateLimitListFinancialEvents          *rate.Limiter
+	HttpClient httpx.Client
 }
 
 func NewAPI(httpClient httpx.Client) API {
 	return &api{
-		HttpClient:                            httpClient,
-		RateLimitListFinancialEventGroups:     rate.NewLimiter(rate.Every(time.Millisecond*2100), 1),
-		RateLimitListFinancialEventsByGroupID: rate.NewLimiter(rate.Every(time.Millisecond*2100), 1),
-		RateLimitListFinancialEventsByOrderID: rate.NewLimiter(rate.Every(time.Millisecond*2100), 1),
-		RateLimitListFinancialEvents:          rate.NewLimiter(rate.Every(time.Millisecond*2100), 1),
+		HttpClient: httpClient,
 	}
 }
 
@@ -48,7 +37,6 @@ func (a *api) ListFinancialEventGroups(filter *ListFinancialEventGroupsFilter) (
 
 	return apis.NewCall[ListFinancialEventGroupsResponse](http.MethodGet, pathPrefix+"/financialEventGroups").
 		WithQueryParams(filter.GetQuery()).
-		WithRateLimiter(a.RateLimitListFinancialEventGroups).
 		Execute(a.HttpClient)
 }
 
@@ -59,7 +47,6 @@ func (a *api) ListFinancialEventsByGroupID(eventGroupID string, filter *ListFina
 
 	return apis.NewCall[ListFinancialEventsResponse](http.MethodGet, pathPrefix+"/financialEventGroups/"+eventGroupID+"/financialEvents").
 		WithQueryParams(filter.GetQuery()).
-		WithRateLimiter(a.RateLimitListFinancialEventsByGroupID).
 		Execute(a.HttpClient)
 }
 
@@ -70,7 +57,6 @@ func (a *api) ListFinancialEventsByOrderID(orderID string, filter *ListFinancial
 
 	return apis.NewCall[ListFinancialEventsResponse](http.MethodGet, pathPrefix+"/orders/"+orderID+"/financialEvents").
 		WithQueryParams(filter.GetQuery()).
-		WithRateLimiter(a.RateLimitListFinancialEventsByOrderID).
 		Execute(a.HttpClient)
 }
 
@@ -81,6 +67,5 @@ func (a *api) ListFinancialEvents(filter *ListFinancialEventsFilter) (*apis.Call
 
 	return apis.NewCall[ListFinancialEventsResponse](http.MethodGet, pathPrefix+"/financialEvents").
 		WithQueryParams(filter.GetQuery()).
-		WithRateLimiter(a.RateLimitListFinancialEvents).
 		Execute(a.HttpClient)
 }

--- a/apis/orders/orders.go
+++ b/apis/orders/orders.go
@@ -3,10 +3,8 @@ package orders
 import (
 	"github.com/fond-of-vertigo/amazon-sp-api/apis"
 	"github.com/fond-of-vertigo/amazon-sp-api/httpx"
-	"golang.org/x/time/rate"
 	"net/http"
 	"net/url"
-	"time"
 )
 
 const pathPrefix = "/orders/v0"
@@ -18,14 +16,12 @@ type API interface {
 }
 
 type api struct {
-	HttpClient             httpx.Client
-	RateLimitGetOrderItems *rate.Limiter
+	HttpClient httpx.Client
 }
 
 func NewAPI(httpClient httpx.Client) API {
 	return &api{
-		HttpClient:             httpClient,
-		RateLimitGetOrderItems: rate.NewLimiter(rate.Every(time.Second/2), 30),
+		HttpClient: httpClient,
 	}
 }
 
@@ -36,6 +32,5 @@ func (a *api) GetOrderItems(orderID string, nextToken *string) (*apis.CallRespon
 	}
 	return apis.NewCall[GetOrderItemsResponse](http.MethodGet, pathPrefix+"/orders/"+orderID+"/orderItems").
 		WithQueryParams(params).
-		WithRateLimiter(a.RateLimitGetOrderItems).
 		Execute(a.HttpClient)
 }

--- a/apis/reports/reports.go
+++ b/apis/reports/reports.go
@@ -6,11 +6,9 @@ import (
 	"github.com/fond-of-vertigo/amazon-sp-api/apis"
 	"github.com/fond-of-vertigo/amazon-sp-api/httpx"
 	"go/types"
-	"golang.org/x/time/rate"
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 )
 
 const pathPrefix = "/reports/2021-06-30"
@@ -43,31 +41,12 @@ type API interface {
 }
 
 type api struct {
-	HttpClient                    httpx.Client
-	RateLimitGetReports           *rate.Limiter
-	RateLimitCreateReport         *rate.Limiter
-	RateLimitGetReport            *rate.Limiter
-	RateLimitCancelReport         *rate.Limiter
-	RateLimitGetReportSchedules   *rate.Limiter
-	RateLimitCreateReportSchedule *rate.Limiter
-	RateLimitGetReportSchedule    *rate.Limiter
-	RateLimitCancelReportSchedule *rate.Limiter
-	RateLimitGetReportDocument    *rate.Limiter
+	HttpClient httpx.Client
 }
 
 func NewAPI(httpClient httpx.Client) API {
-
 	return &api{
-		HttpClient:                    httpClient,
-		RateLimitGetReports:           rate.NewLimiter(rate.Every(time.Microsecond*22200), 10),
-		RateLimitCreateReport:         rate.NewLimiter(rate.Every(time.Microsecond*16700), 15),
-		RateLimitGetReport:            rate.NewLimiter(rate.Every(time.Second*2), 15),
-		RateLimitCancelReport:         rate.NewLimiter(rate.Every(time.Microsecond*22200), 10),
-		RateLimitGetReportSchedules:   rate.NewLimiter(rate.Every(time.Microsecond*22200), 10),
-		RateLimitCreateReportSchedule: rate.NewLimiter(rate.Every(time.Microsecond*22200), 10),
-		RateLimitGetReportSchedule:    rate.NewLimiter(rate.Every(time.Microsecond*22200), 10),
-		RateLimitCancelReportSchedule: rate.NewLimiter(rate.Every(time.Microsecond*22200), 10),
-		RateLimitGetReportDocument:    rate.NewLimiter(rate.Every(time.Microsecond*22200), 15),
+		HttpClient: httpClient,
 	}
 }
 
@@ -78,7 +57,6 @@ func (r *api) GetReports(filter *GetReportsFilter) (*apis.CallResponse[GetReport
 	return apis.NewCall[GetReportsResponse](http.MethodGet, pathPrefix+"/reports").
 		WithQueryParams(filter.GetQuery()).
 		WithParseErrorListOnError(true).
-		WithRateLimiter(r.RateLimitGetReports).
 		Execute(r.HttpClient)
 }
 
@@ -90,20 +68,17 @@ func (r *api) CreateReport(specification *CreateReportSpecification) (*apis.Call
 	return apis.NewCall[CreateReportResponse](http.MethodPost, pathPrefix+"/reports").
 		WithBody(body).
 		WithParseErrorListOnError(true).
-		WithRateLimiter(r.RateLimitCreateReport).
 		Execute(r.HttpClient)
 }
 
 func (r *api) GetReport(reportID string) (*apis.CallResponse[GetReportResponse], error) {
 	return apis.NewCall[GetReportResponse](http.MethodGet, pathPrefix+"/reports/"+reportID).
 		WithParseErrorListOnError(true).
-		WithRateLimiter(r.RateLimitGetReport).
 		Execute(r.HttpClient)
 }
 
 func (r *api) CancelReport(reportID string) error {
 	_, err := apis.NewCall[types.Nil](http.MethodDelete, pathPrefix+"/reports/"+reportID).
-		WithRateLimiter(r.RateLimitCancelReport).
 		Execute(r.HttpClient)
 	return err
 }
@@ -117,7 +92,6 @@ func (r *api) GetReportSchedules(reportTypes []string) (*apis.CallResponse[GetRe
 	return apis.NewCall[GetReportsResponse](http.MethodGet, pathPrefix+"/schedules").
 		WithQueryParams(params).
 		WithParseErrorListOnError(true).
-		WithRateLimiter(r.RateLimitGetReportSchedules).
 		Execute(r.HttpClient)
 }
 
@@ -129,20 +103,17 @@ func (r *api) CreateReportSchedule(specification *CreateReportScheduleSpecificat
 	return apis.NewCall[CreateReportScheduleResponse](http.MethodPost, pathPrefix+"/schedules").
 		WithBody(body).
 		WithParseErrorListOnError(true).
-		WithRateLimiter(r.RateLimitCreateReportSchedule).
 		Execute(r.HttpClient)
 }
 
 func (r *api) GetReportSchedule(reportScheduleID string) (*apis.CallResponse[GetReportScheduleResponse], error) {
 	return apis.NewCall[GetReportScheduleResponse](http.MethodGet, pathPrefix+"/schedules/"+reportScheduleID).
 		WithParseErrorListOnError(true).
-		WithRateLimiter(r.RateLimitGetReportSchedule).
 		Execute(r.HttpClient)
 }
 
 func (r *api) CancelReportSchedule(reportScheduleID string) error {
 	_, err := apis.NewCall[types.Nil](http.MethodDelete, pathPrefix+"/schedules/"+reportScheduleID).
-		WithRateLimiter(r.RateLimitCancelReportSchedule).
 		Execute(r.HttpClient)
 	return err
 }
@@ -151,6 +122,5 @@ func (r *api) GetReportDocument(reportDocumentID string, restrictedDataToken *st
 	return apis.NewCall[GetReportDocumentResponse](http.MethodGet, pathPrefix+"/documents/"+reportDocumentID).
 		WithRestrictedDataToken(restrictedDataToken).
 		WithParseErrorListOnError(true).
-		WithRateLimiter(r.RateLimitGetReportDocument).
 		Execute(r.HttpClient)
 }

--- a/apis/tokens/tokens.go
+++ b/apis/tokens/tokens.go
@@ -4,9 +4,7 @@ import (
 	"encoding/json"
 	"github.com/fond-of-vertigo/amazon-sp-api/apis"
 	"github.com/fond-of-vertigo/amazon-sp-api/httpx"
-	"golang.org/x/time/rate"
 	"net/http"
-	"time"
 )
 
 const pathPrefix = "/tokens/2021-03-01"
@@ -18,14 +16,12 @@ type API interface {
 
 func NewAPI(httpClient httpx.Client) API {
 	return &api{
-		HttpClient:                         httpClient,
-		RateLimitCreateRestrictedDataToken: rate.NewLimiter(rate.Every(time.Second), 10),
+		HttpClient: httpClient,
 	}
 }
 
 type api struct {
-	HttpClient                         httpx.Client
-	RateLimitCreateRestrictedDataToken *rate.Limiter
+	HttpClient httpx.Client
 }
 
 func (t *api) CreateRestrictedDataTokenRequest(restrictedResources *CreateRestrictedDataTokenRequest) (*apis.CallResponse[CreateRestrictedDataTokenResponse], error) {
@@ -35,6 +31,5 @@ func (t *api) CreateRestrictedDataTokenRequest(restrictedResources *CreateRestri
 	}
 	return apis.NewCall[CreateRestrictedDataTokenResponse](http.MethodPost, pathPrefix+"/restrictedDataToken").
 		WithBody(body).
-		WithRateLimiter(t.RateLimitCreateRestrictedDataToken).
 		Execute(t.HttpClient)
 }

--- a/constants/defaults.go
+++ b/constants/defaults.go
@@ -4,5 +4,11 @@ import "time"
 
 // ExpiryDelta describes the puffer-time for a token update before it will expire.
 const ExpiryDelta = 1 * time.Minute
+
+// MaxRetryCount describes the maximum number of retries for a request.
 const MaxRetryCount = 10
-const RetryDelay = 1 * time.Second
+
+// StartingRetryDelay describes the first delay between retries.
+// retries grow exponentially 2^attempts * StartingRetryDelay.
+// Where attempts starts internally at 0.
+const StartingRetryDelay = 1 * time.Second

--- a/constants/defaults.go
+++ b/constants/defaults.go
@@ -4,3 +4,5 @@ import "time"
 
 // ExpiryDelta describes the puffer-time for a token update before it will expire.
 const ExpiryDelta = 1 * time.Minute
+const MaxRetryCount = 10
+const RetryDelay = 1 * time.Second

--- a/constants/global.go
+++ b/constants/global.go
@@ -12,6 +12,7 @@ type Endpoint string
 
 const (
 	AccessTokenHeader = "X-Amz-Access-Token"
+	RateLimitHeader   = "x-amzn-RateLimit-Limit"
 	ServiceExecuteAPI = "execute-api"
 )
 


### PR DESCRIPTION
Instead of hardcoding the rate-limit and be vulnerable to upcoming changes,
the new rate-limiter looks at the response status code (429 - TooManyRequests).
If Amazon has set the Header `x-amzn-RateLimit-Limit` it will be used as a reference for the backoff
till the next retry.

If the Header is not set, a default backoff of currently `1 Second` will be used.
The duration grows exponentially every retry attempt up to `MaxRetryCount`, which is currently set to `10`.

Resulting in a maximum backoff of $2^{10}*1= 1024$ seconds, $1024/60 \sim17$ minutes.