### PR TITLE
Token-Updater: handle ExpiresIn < delta and fix nil return in RunInBackground

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,12 @@ require (
 	github.com/fond-of-vertigo/logger v1.0.1
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.4.0
+	github.com/stretchr/testify v1.8.4
 )
 
-require github.com/jmespath/go-jmespath v0.4.0 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,8 @@
 github.com/aws/aws-sdk-go v1.47.8 h1:VCFyO5UTREnhR0HRf9roqFfJeeRVin58zUy+pBMhwjY=
 github.com/aws/aws-sdk-go v1.47.8/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fond-of-vertigo/logger v1.0.1 h1:WuskIsj8sd6RsrbNCaftUm3btJoHRzi+hksIdogP5NI=
 github.com/fond-of-vertigo/logger v1.0.1/go.mod h1:YxVjEHhE3bvHiJITJ0N5IRLVOQ7Lc9xHkyGs9yupx2M=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
@@ -15,6 +16,11 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/httpx/token_updater.go
+++ b/httpx/token_updater.go
@@ -111,9 +111,11 @@ func (t *PeriodicTokenUpdater) doInitialFetch() (time.Duration, error) {
 }
 
 func durationBetweenTokenRequests(token *AccessTokenResponse) time.Duration {
-	secondsToWait := token.ExpiresIn - int(constants.ExpiryDelta/time.Second)
-	durationToWait := time.Duration(secondsToWait) * time.Second
-	return durationToWait
+	expiryDeltaSeconds := int(constants.ExpiryDelta.Seconds())
+	if token.ExpiresIn <= expiryDeltaSeconds {
+		return time.Duration(token.ExpiresIn) * time.Second
+	}
+	return time.Duration(token.ExpiresIn-expiryDeltaSeconds) * time.Second
 }
 
 func (t *PeriodicTokenUpdater) doTokenRequest() (*AccessTokenResponse, error) {

--- a/httpx/token_updater.go
+++ b/httpx/token_updater.go
@@ -65,7 +65,7 @@ func (t *PeriodicTokenUpdater) GetAccessToken() string {
 func (t *PeriodicTokenUpdater) RunInBackground() (cancel func(), err error) {
 	durationNextFetch, err := t.doInitialFetch()
 	if err != nil {
-		return nil, err
+		return func() {}, err
 	}
 
 	ticker := time.NewTicker(durationNextFetch)

--- a/httpx/token_updater_test.go
+++ b/httpx/token_updater_test.go
@@ -1,0 +1,123 @@
+package httpx
+
+import (
+	"encoding/json"
+	"errors"
+	"github.com/fond-of-vertigo/logger"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type mockHTTPClient struct {
+	testing.TB
+	URL              string
+	BodyType         string
+	Body             []byte
+	PostCallCount    int
+	MockResponseBody []byte
+}
+
+func (m *mockHTTPClient) Do(_ *http.Request) (*http.Response, error) {
+	return nil, nil
+}
+
+func (m *mockHTTPClient) Post(url string, bodyType string, body io.Reader) (*http.Response, error) {
+	m.PostCallCount++
+	assert.Equal(m, m.URL, url)
+	assert.Equal(m, m.BodyType, bodyType)
+
+	assert.NotNil(m, body)
+	acutalBody, err := io.ReadAll(body)
+	assert.NoError(m, err)
+	assert.Equal(m, m.Body, acutalBody)
+
+	resp := httptest.NewRecorder()
+	_, err = resp.Write(m.MockResponseBody)
+	assert.NoError(m, err)
+	return resp.Result(), nil
+}
+
+func TestPeriodicTokenUpdater_RunInBackground(t *testing.T) {
+	type args struct {
+		RefreshToken      string
+		ClientID          string
+		ClientSecret      string
+		ExpectedPostCount int
+		MockTokenResponse AccessTokenResponse
+	}
+	tests := []struct {
+		name      string
+		WantError error
+
+		args args
+	}{
+		{
+			name:      "Simple",
+			WantError: nil,
+			args: args{
+				RefreshToken:      "refreshToken",
+				ClientID:          "clientID",
+				ClientSecret:      "clientSecret",
+				ExpectedPostCount: 2,
+				MockTokenResponse: AccessTokenResponse{AccessToken: "accessToken", ExpiresIn: 1},
+			},
+		},
+		{
+			name:      "Fail",
+			WantError: errors.New("refreshToken response did not contain access token"),
+			args: args{
+				RefreshToken:      "refreshToken",
+				ClientID:          "clientID",
+				ClientSecret:      "clientSecret",
+				ExpectedPostCount: 1,
+				MockTokenResponse: AccessTokenResponse{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			respBody, err := json.Marshal(tt.args.MockTokenResponse)
+			assert.NoError(t, err)
+
+			tu := newTokenUpdater(TokenUpdaterConfig{
+				RefreshToken: tt.args.RefreshToken,
+				ClientID:     tt.args.ClientID,
+				ClientSecret: tt.args.ClientSecret,
+				HTTPClient: &mockHTTPClient{
+					TB:               t,
+					URL:              tokenURL,
+					BodyType:         "application/json",
+					Body:             makeRequestBody(tt.args.RefreshToken, tt.args.ClientID, tt.args.ClientSecret),
+					MockResponseBody: respBody,
+				},
+				Logger: logger.New(logger.LvlTrace),
+			})
+
+			//  when
+			cancel, err := tu.RunInBackground()
+
+			// then
+			if tt.WantError != nil {
+				assert.Error(t, err, tt.WantError)
+			}
+
+			assert.Equal(t, tt.args.MockTokenResponse.AccessToken, tu.GetAccessToken())
+			time.Sleep(time.Duration(tt.args.MockTokenResponse.ExpiresIn) * time.Second)
+			assert.Equal(t, tt.args.MockTokenResponse.AccessToken, tu.GetAccessToken())
+
+			// wait for the next update
+			time.Sleep((time.Duration(tt.args.MockTokenResponse.ExpiresIn) * time.Second) - time.Duration(500)*time.Millisecond)
+			cancel()
+
+			assert.Equal(t, tt.args.MockTokenResponse.AccessToken, tu.GetAccessToken())
+			time.Sleep(time.Duration(tt.args.MockTokenResponse.ExpiresIn) * time.Second)
+			assert.Equal(t, tt.args.MockTokenResponse.AccessToken, tu.GetAccessToken())
+			assert.Equal(t, tt.args.ExpectedPostCount, tu.httpClient.(*mockHTTPClient).PostCallCount)
+		})
+	}
+}


### PR DESCRIPTION
+ `RunInBackground` returns a cancel func, which should never be nil, instead use an empty anonymous function
+ `durationBetweenTokenRequests` must handle the case where `token.ExpiresIn` is smaller than `constants.ExpiryDelta`, s.t. no negative durations occur

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206157524444029