### PR TITLE
Remove contentLength check in api caller

### DIFF
--- a/apis/caller.go
+++ b/apis/caller.go
@@ -94,10 +94,8 @@ func (a *Call[responseType]) Execute(httpClient HTTPClient) (*CallResponse[respo
 		return callResp, err
 	}
 
-	if resp.ContentLength > 0 {
-		if err = unmarshalBody(resp, &callResp.ResponseBody); err != nil {
-			return nil, err
-		}
+	if err = unmarshalBody(resp, &callResp.ResponseBody); err != nil {
+		return nil, err
 	}
 	return callResp, nil
 }


### PR DESCRIPTION
Amazon stopped providing the ContentLength, resulting in not unmarshalling the body, even if it was given in the response