### PR TITLE
Use UTC as timezone for JsonTimeISO8601

### DIFF
--- a/apis/json_time.go
+++ b/apis/json_time.go
@@ -10,10 +10,13 @@ type JsonTimeISO8601 struct {
 }
 
 func (t JsonTimeISO8601) MarshalJSON() ([]byte, error) {
-	value := "\"" + t.Format(time.RFC3339) + "\""
+	value := "\"" + t.UTC().Format(time.RFC3339) + "\""
 	return []byte(value), nil
 }
 
 func (t JsonTimeISO8601) String() string {
-	return t.Format(time.RFC3339)
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
 }

--- a/apis/json_time_test.go
+++ b/apis/json_time_test.go
@@ -17,11 +17,35 @@ func TestJsonTimeISO8601_MarshalJSON(t1 *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Seconds",
+			name: "Seconds in UTC",
 			fields: fields{
 				Time: time.Date(2022, 02, 26, 9, 12, 11, 0, time.UTC),
 			},
 			want:    []byte("\"2022-02-26T09:12:11Z\""),
+			wantErr: false,
+		},
+		{
+			name: "Zero Time",
+			fields: fields{
+				Time: time.Time{},
+			},
+			want:    []byte("\"0001-01-01T00:00:00Z\""),
+			wantErr: false,
+		},
+		{
+			name: "Time in PST",
+			fields: fields{
+				Time: time.Date(2022, 02, 26, 1, 12, 11, 0, time.FixedZone("PST", -8*3600)),
+			},
+			want:    []byte("\"2022-02-26T09:12:11Z\""), // Converted to UTC
+			wantErr: false,
+		},
+		{
+			name: "Time in IST",
+			fields: fields{
+				Time: time.Date(2022, 02, 26, 14, 42, 11, 0, time.FixedZone("IST", 5*3600+1800)),
+			},
+			want:    []byte("\"2022-02-26T09:12:11Z\""), // Converted to UTCc
 			wantErr: false,
 		},
 	}

--- a/apis/orders/orders.go
+++ b/apis/orders/orders.go
@@ -40,6 +40,7 @@ func (a *API) GetOrders(filter *GetOrdersFilter, restrictedDataToken *string) (*
 		WithQueryParams(filter.GetQuery()).
 		WithRateLimit(0.0167, time.Second).
 		WithRestrictedDataToken(restrictedDataToken).
+		WithParseErrorListOnError().
 		Execute(a.httpClient)
 }
 


### PR DESCRIPTION
Fixes: https://github.com/fond-of-vertigo/amazon-sp-api/issues/48