### PR TITLE
Use string instead of bool for IsReplacementOrder in Order model

### DIFF
--- a/apis/orders/model.go
+++ b/apis/orders/model.go
@@ -328,7 +328,7 @@ type Order struct {
 	// The order ID value for the order that is being replaced. Returned only if IsReplacementOrder = true.
 	ReplacedOrderId *string `json:"ReplacedOrderId,omitempty"`
 	// When true, this is a replacement order.
-	IsReplacementOrder *bool `json:"IsReplacementOrder,omitempty"`
+	IsReplacementOrder *string `json:"IsReplacementOrder,omitempty"`
 	// Indicates the date by which the seller must respond to the buyer with an estimated ship date. Returned only for Sourcing on Demand orders.
 	PromiseResponseDueDate *string `json:"PromiseResponseDueDate,omitempty"`
 	// When true, the estimated ship date is set for the order. Returned only for Sourcing on Demand orders.


### PR DESCRIPTION
This is a quick fix for a known bug in https://github.com/amzn/selling-partner-api-models/issues/2647.
This may be reverted if fix.